### PR TITLE
Fix crash when replacing non-existent waypoint

### DIFF
--- a/scripts/patrol-gui.lua
+++ b/scripts/patrol-gui.lua
@@ -499,7 +499,7 @@ function PatrolGui.toggle_on_patrol(player, spidertron, gui_elements)
   local switch = gui_elements.on_patrol_switch
   local waypoint_info = global.spidertron_waypoints[spidertron.unit_number]
   local on_patrol = switch.switch_state == "left"
-  if not waypoint_info and on_patrol then
+  if not waypoint_info then
     waypoint_info = get_waypoint_info(spidertron)
   end
   set_on_patrol(on_patrol, spidertron, waypoint_info)

--- a/scripts/patrol-gui.lua
+++ b/scripts/patrol-gui.lua
@@ -499,6 +499,9 @@ function PatrolGui.toggle_on_patrol(player, spidertron, gui_elements)
   local switch = gui_elements.on_patrol_switch
   local waypoint_info = global.spidertron_waypoints[spidertron.unit_number]
   local on_patrol = switch.switch_state == "left"
+  if not waypoint_info and on_patrol then
+    waypoint_info = get_waypoint_info(spidertron)
+  end
   set_on_patrol(on_patrol, spidertron, waypoint_info)
 end
 

--- a/scripts/spidertron-control.lua
+++ b/scripts/spidertron-control.lua
@@ -27,7 +27,7 @@ function SpidertronControl.on_patrol_command_issued(spidertron, position, index,
 
   -- Add to patrol
   if not index then index = #waypoint_info.waypoints end
-  if replace then
+  if replace and #waypoint_info.waypoints > 0 then
     local waypoint = waypoint_info.waypoints[index]
     waypoint.position = position
     waypoint_info.waypoints[index] = waypoint


### PR DESCRIPTION
First commit: See https://mods.factorio.com/mod/SpidertronPatrols/discussion/643bb03b8fa504dfd56e3fda

Steps to reproduce crash: 
1. Create a new save and place a spidetron/spiderling
2. Grab the waypoint remote
3. Shift-click to replace a waypoint
The game will then crash. With this fix, it will instead create a new waypoint.

Second commit: See https://mods.factorio.com/mod/SpidertronPatrols/discussion/643b9d6d76dea792c8d2fec4

Steps to reproduce crash: 
1. Create a new save and place a spidetron/spiderling
2. Grab the waypoint remote and place a waypoint
3. Press the red reset button or ctrl-right click to delete all waypoints
4. Turn on automatic patrolling
The game will then crash. With this fix, it will instead create an empty waypoint_info and do nothing.

Alternatively:
1. Create a new save and place a spidetron/spiderling
2. Grab the waypoint remote and place a waypoint
3. Turn on automatic patrolling
4. Press the red reset button or ctrl-right click to delete all waypoints
5. Turn off automatic patrolling

This doesn't crash if you delete the waypoint with the small x button in the list - I think this shows a minor bug, leaving some extra data which is otherwise properly removed.
This does leave the spidertron in a state where automatic patrols are on and there are no waypoints. However, this is also possible by deleting the waypoint of a patrolling spidetron with the small x buttons.
