### PR TITLE
Add Maraxsis compatibility

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -3,7 +3,6 @@ util = require "util"
 require "scripts.utils"
 gui = require "scripts.gui-lite"
 
-RemoteInterface = require "scripts.remote-interface"
 local Dock = require "scripts.dock"
 local PatrolGui = require "scripts.patrol-gui"
 SpidertronControl = require "scripts.spidertron-control"
@@ -34,6 +33,25 @@ storage.spidertron_waypoints: indexed by spidertron.unit_number:
   on_patrol :: bool
   renders :: array of LuaRenderObject
 ]]
+
+
+function get_waypoint_info(spidertron)
+  local waypoint_info = storage.spidertron_waypoints[spidertron.unit_number]
+  if not waypoint_info then
+    log("No waypoint info found. Creating blank table")
+    storage.spidertron_waypoints[spidertron.unit_number] = {
+      spidertron = spidertron,
+      waypoints = {},
+      renders = {},
+      current_index = 1,
+      on_patrol = false
+    }
+    waypoint_info = storage.spidertron_waypoints[spidertron.unit_number]
+  end
+  return waypoint_info
+end
+
+RemoteInterface = require "scripts.remote-interface"
 
 function Control.clear_spidertron_waypoints(spidertron, unit_number)
   -- Called on custom-input or whenever the current autopilot_destination is removed or when the spidertron is removed.

--- a/control.lua
+++ b/control.lua
@@ -35,23 +35,6 @@ storage.spidertron_waypoints: indexed by spidertron.unit_number:
   renders :: array of LuaRenderObject
 ]]
 
-
-function get_waypoint_info(spidertron)
-  local waypoint_info = storage.spidertron_waypoints[spidertron.unit_number]
-  if not waypoint_info then
-    log("No waypoint info found. Creating blank table")
-    storage.spidertron_waypoints[spidertron.unit_number] = {
-      spidertron = spidertron,
-      waypoints = {},
-      renders = {},
-      current_index = 1,
-      on_patrol = false
-    }
-    waypoint_info = storage.spidertron_waypoints[spidertron.unit_number]
-  end
-  return waypoint_info
-end
-
 function Control.clear_spidertron_waypoints(spidertron, unit_number)
   -- Called on custom-input or whenever the current autopilot_destination is removed or when the spidertron is removed.
   -- Pass in either `spidertron` or `unit_number`

--- a/scripts/remote-interface.lua
+++ b/scripts/remote-interface.lua
@@ -1,5 +1,21 @@
 local RemoteInterface = {}
 
+function get_waypoint_info(spidertron)
+  local waypoint_info = storage.spidertron_waypoints[spidertron.unit_number]
+  if not waypoint_info then
+    log("No waypoint info found. Creating blank table")
+    storage.spidertron_waypoints[spidertron.unit_number] = {
+      spidertron = spidertron,
+      waypoints = {},
+      renders = {},
+      current_index = 1,
+      on_patrol = false
+    }
+    waypoint_info = storage.spidertron_waypoints[spidertron.unit_number]
+  end
+  return waypoint_info
+end
+
 local function remote_interface_assign_waypoints(spidertron, waypoints)
   for _, waypoint in pairs(waypoints) do
     SpidertronControl.on_patrol_command_issued(spidertron, waypoint.position)
@@ -11,6 +27,7 @@ remote.add_interface("SpidertronPatrols", {
   get_events = function() return {on_spidertron_given_new_destination = on_spidertron_given_new_destination} end,
   clear_waypoints = function(unit_number) Control.clear_spidertron_waypoints(nil, unit_number) end,
   add_waypoints = function(spidertron, waypoints) remote_interface_assign_waypoints(spidertron, waypoints) end,
+  get_waypoints = get_waypoint_info,
   give_patrol_remote = function(player, spidertron, waypoint_index)  -- waypoint_index is optional
     PatrolRemote.give_remote(player, spidertron, waypoint_index)
   end,

--- a/scripts/remote-interface.lua
+++ b/scripts/remote-interface.lua
@@ -1,21 +1,5 @@
 local RemoteInterface = {}
 
-function get_waypoint_info(spidertron)
-  local waypoint_info = storage.spidertron_waypoints[spidertron.unit_number]
-  if not waypoint_info then
-    log("No waypoint info found. Creating blank table")
-    storage.spidertron_waypoints[spidertron.unit_number] = {
-      spidertron = spidertron,
-      waypoints = {},
-      renders = {},
-      current_index = 1,
-      on_patrol = false
-    }
-    waypoint_info = storage.spidertron_waypoints[spidertron.unit_number]
-  end
-  return waypoint_info
-end
-
 local function remote_interface_assign_waypoints(spidertron, waypoints)
   for _, waypoint in pairs(waypoints) do
     SpidertronControl.on_patrol_command_issued(spidertron, waypoint.position)


### PR DESCRIPTION
This PR adds the "get_waypoints" function onto the remote API. It allows read access of the spidertron waypoints from the remote API.

This is used in maraxsis to read the waypoints and send the submarine to the trench based on the schedule status.