### PR TITLE
Update for Factorio 2.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.6.5
+Date: ????
+  Changes:
+    - Updated for Factorio 2.1.
+    - Migrated nullius recipe `category` to the new 2.1 `categories` table.
+---------------------------------------------------------------------------------------------------
 Version: 2.6.4
 Date: 13 April 2026
   Bugfixes:

--- a/info.json
+++ b/info.json
@@ -1,11 +1,11 @@
 {
     "name": "SpidertronPatrols",
-    "version": "2.6.4",
+    "version": "2.6.5",
     "title": "Spidertron Patrols",
     "author": "Xorimuth",
     "homepage": "https://discord.gg/pkJc4v9nfT",
     "description": "Send spidertrons on patrols and automatically load and unload them using docks. Adds mid-game spiderling to allow the new features to be used sooner.",
-    "factorio_version": "2.0",
+    "factorio_version": "2.1",
     "dependencies": [
         "base >= 2.0.38",
         "? space-age",

--- a/prototypes/nullius.lua
+++ b/prototypes/nullius.lua
@@ -41,7 +41,7 @@ if spiderling_enabled then
   recipe.group = "equipment"
   recipe.subgroup = "vehicle"
   recipe.order = "nullius-da"
-  recipe.category = "medium-crafting"
+  recipe.categories = {"medium-crafting"}
   recipe.energy_required = 60
   recipe.ingredients = {
     {type="item", name="nullius-car-2", amount=1},
@@ -79,7 +79,7 @@ if dock_enabled and sp_data_stage ~= "data" then
   recipe.group = "equipment"
   recipe.subgroup = "vehicle"
   recipe.order = "nullius-dh"
-  recipe.category = "medium-crafting"
+  recipe.categories = {"medium-crafting"}
   recipe.energy_required = 60
   recipe.ingredients = {
     {type="item", name="nullius-large-chest-2", amount=2},


### PR DESCRIPTION
Brings the mod up to Factorio 2.1.

Two things changed. info.json gets `factorio_version: 2.1`. And in `prototypes/nullius.lua`, the two recipes that set `category = "medium-crafting"` now use `categories = {"medium-crafting"}`, since 2.1 collapsed the old `category`/`additional_categories` fields into a single `categories` list. That nullius branch only runs when nullius is active, which I didn't have installed, so I couldn't watch it execute; the edit mirrors the exact change the base game made.

Loaded clean under 2.1.7 with Space Age and SpidertronEnhancements, pulled in as a dependency of another mod, with no errors at the data stage. I didn't drive patrols or docks at runtime, so those are worth a look before you trust it.

I also bumped the version to 2.6.5 and dropped a `Date: ????` changelog stub so my fork could build. Strip that and version it however suits your release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
